### PR TITLE
Added alternative singleton implementation for MapPage

### DIFF
--- a/mTransit/src/app/app.module.ts
+++ b/mTransit/src/app/app.module.ts
@@ -42,7 +42,7 @@ let storage: Storage = new Storage();
     SmsCodePage,
     DriverLoginPage
   ],
-  providers: [{provide: ErrorHandler, useClass:IonicErrorHandler}]
+  providers: [{provide: ErrorHandler, useClass:IonicErrorHandler}, MapPage]
 })
 export class AppModule {}
 export function createTranslateLoader(http: Http) {

--- a/mTransit/src/pages/map/map.ts
+++ b/mTransit/src/pages/map/map.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Injectable } from 'angular2/core';
 import { NavController, Platform } from 'ionic-angular';
 import { 
   GoogleMap, 


### PR DESCRIPTION
MapPage added use of Injectable import and a single instance is declared in app.module.ts to ensure no other instances are created.